### PR TITLE
lowercase email on registration and login

### DIFF
--- a/web/controllers/auth.ex
+++ b/web/controllers/auth.ex
@@ -44,7 +44,7 @@ defmodule Bep.Auth do
 
   def login_by_email_and_pass(conn, email, given_pass, opts) do
     repo = Keyword.fetch!(opts, :repo)
-    user = repo.get_by(Bep.User, email: email)
+    user = repo.get_by(Bep.User, email: String.downcase(email))
 
     cond do
       user && checkpw(given_pass, user.password_hash) ->

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -18,6 +18,7 @@ defmodule Bep.User do
     model
     |> cast(params, [:email])
     |> validate_required([:email])
+    |> email_lowercase()
     |> unique_constraint(:email)
   end
 
@@ -34,6 +35,15 @@ defmodule Bep.User do
     case changeset do
       %Ecto.Changeset{valid?: true, changes: %{password: pass}} ->
         put_change(changeset, :password_hash, Bcrypt.hashpwsalt(pass))
+      _ ->
+        changeset
+    end
+  end
+
+  defp email_lowercase(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{email: email}} ->
+        put_change(changeset, :email, String.downcase(email))
       _ ->
         changeset
     end


### PR DESCRIPTION
ref: https://github.com/dwyl/best-evidence/issues/70#issuecomment-317481683

Make sure the emails are case insensitive: - lowercase email on registration + lowercase email on login