### PR TITLE
Consent page

### DIFF
--- a/test/controllers/consent_controller_test.exs
+++ b/test/controllers/consent_controller_test.exs
@@ -11,7 +11,7 @@ defmodule Bep.ConsentControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get conn, "/consent"
-    assert html_response(conn, 200) =~ "Create a BestEvidence account"
+    assert html_response(conn, 200) =~ "Create an Account"
   end
 
   @tag login_as: %{email: "email@example.com"}

--- a/test/controllers/consent_controller_test.exs
+++ b/test/controllers/consent_controller_test.exs
@@ -1,0 +1,22 @@
+defmodule Bep.ConsentControllerTest do
+  use Bep.ConnCase
+  setup %{conn: conn} = config do
+    if user = config[:login_as] do
+      conn = assign(conn, :current_user, user)
+      {:ok, conn: conn, user: user}
+    else
+      :ok
+    end
+  end
+
+  test "GET /", %{conn: conn} do
+    conn = get conn, "/consent"
+    assert html_response(conn, 200) =~ "Create a BestEvidence account"
+  end
+
+  @tag login_as: %{email: "email@example.com"}
+  test "GET / redirect to /search when logged in", %{conn: conn} do
+    conn = get conn, "/consent"
+    assert html_response(conn, 302)
+  end
+end

--- a/test/controllers/consent_controller_test.exs
+++ b/test/controllers/consent_controller_test.exs
@@ -11,7 +11,7 @@ defmodule Bep.ConsentControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get conn, "/consent"
-    assert html_response(conn, 200) =~ "Create an Account"
+    assert html_response(conn, 200) =~ "I understand that data entered may be used for reasearch"
   end
 
   @tag login_as: %{email: "email@example.com"}

--- a/web/controllers/consent_controller.ex
+++ b/web/controllers/consent_controller.ex
@@ -1,0 +1,11 @@
+defmodule Bep.ConsentController do
+  use Bep.Web, :controller
+
+  def index(conn, _) do
+    if conn.assigns.current_user do
+      redirect(conn, to: search_path(conn, :index))
+    else
+      render conn, "index.html"
+    end
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -20,6 +20,7 @@ defmodule Bep.Router do
     get "/", PageController, :index
     resources "/users", UserController, only: [:new, :create]
     resources "/sessions", SessionController, only: [:new, :create]
+    resources "/consent", ConsentController, only: [:index]
   end
 
   scope "/", Bep do

--- a/web/templates/consent/index.html.eex
+++ b/web/templates/consent/index.html.eex
@@ -1,5 +1,5 @@
-<section class="bep-bg-green tc white pv5">
-  <h1 class="f3 fw1 lh-copy pt3 mv0">Create a BestEvidence account</h1>
+<section class="bep-bg-green tc white pt5 pb4">
+  <h1 class="f3 fw1 lh-copy pt3 mv0">Create an Account</h1>
 </section>
 <section class="pa3 w-80 w-30-ns center">
   <p class="mv1">
@@ -9,7 +9,7 @@
   <p>
     To create an account you will need to consent to this by clicking on the button below.
   </p>
-  <div class="tc mv5">
+  <div class="tc mv4">
     <%= link "I Agree", to: user_path(@conn, :new), class: "bep-bg-green white ph4 pv3 ba br2 link db mb4 center pointer" %>
   </div>
 </section>

--- a/web/templates/consent/index.html.eex
+++ b/web/templates/consent/index.html.eex
@@ -1,15 +1,15 @@
-<div class="pa3 w-50-ns center">
-  <p class="ph3">Granting us access to your data will help us to improve:</p>
-  <ul class="b">
-    <li>Accuracy of search results</li>
-    <li>Quality of answers</li>
-    <li>Most useful features to include</li>
-  </ul>
-  <img src="images/blue-info.svg" alt="info" class="v-mid pl2 pl3-ns pr1">
-  <p class="dib bep-blue">
-    All of your data will be anonymised
+<section class="bep-bg-green tc white pv5">
+  <h1 class="f3 fw1 lh-copy pt3 mv0">Create a BestEvidence account</h1>
+</section>
+<section class="pa3 w-80 w-30-ns center">
+  <p class="mv1">
+    Searches and notes made while using this app are stored in a secure database.
+    Data are accessible to the app administrators in an anonymised format and may be analysed to understand how people use the app to help improve the it.
+  </p>
+  <p>
+    To create an account you will need to consent to this by clicking on the button below.
   </p>
   <div class="tc mv5">
-    <%= link "I Agree", to: user_path(@conn, :new), class: "pointer bep-bg-green white ph4 pv3 br2 link" %>
+    <%= link "I Agree", to: user_path(@conn, :new), class: "bep-bg-green white ph4 pv3 ba br2 link db mb4 center pointer" %>
   </div>
-</div>
+</section>

--- a/web/templates/consent/index.html.eex
+++ b/web/templates/consent/index.html.eex
@@ -10,6 +10,9 @@
     To create an account you will need to consent to this by clicking on the button below.
   </p>
   <div class="tc mv4">
-    <%= link "I Agree", to: user_path(@conn, :new), class: "bep-bg-green white ph4 pv3 ba br2 link db mb4 center pointer" %>
+    <%= link "I understand that data entered may be used for reasearch", to: user_path(@conn, :new), class: "bep-bg-green white ph4 pv3 ba br2 link db mb4 center pointer" %>
   </div>
+  <p>
+    <b>Remember not to write any notes that could breach the patients' confidentiality or allow them to be identified.</b>
+  </p>
 </section>

--- a/web/templates/consent/index.html.eex
+++ b/web/templates/consent/index.html.eex
@@ -1,0 +1,15 @@
+<div class="pa3 w-50-ns center">
+  <p class="ph3">Granting us access to your data will help us to improve:</p>
+  <ul class="b">
+    <li>Accuracy of search results</li>
+    <li>Quality of answers</li>
+    <li>Most useful features to include</li>
+  </ul>
+  <img src="images/blue-info.svg" alt="info" class="v-mid pl2 pl3-ns pr1">
+  <p class="dib bep-blue">
+    All of your data will be anonymised
+  </p>
+  <div class="tc mv5">
+    <%= link "I Agree", to: user_path(@conn, :new), class: "pointer bep-bg-green white ph4 pv3 br2 link" %>
+  </div>
+</div>

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -35,11 +35,13 @@
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KTZP7DM"
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <!-- End Google Tag Manager (noscript) -->
-      <p class="tl ph3 pv2 mv0 bg-moon-gray">Best Evidence is in Alpha - <a href="mailto:bestevidencefeedback@gmail.com" class="black" >give feedback</a> to help improve it.</p>
+      <div class="fixed top-0 z-5 w-100">
+        <p class="tl ph3 pv2 mv0 bg-moon-gray">Best Evidence is in Alpha - <a href="mailto:bestevidencefeedback@gmail.com" class="black" >give feedback</a> to help improve it.</p>
+      </div>
       <p class="alert alert-info ma0" role="alert"><%= get_flash(@conn, :info) %></p>
       <p class="alert alert-danger ma0" role="alert"><%= get_flash(@conn, :error) %></p>
 
-      <main role="main">
+      <main role="main pv5">
         <%= render @view_module, @view_template, assigns %>
       </main>
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -1,15 +1,7 @@
-<div class="bep-bg-green tc white pb4">
+<div class="bep-bg-green tc white pv5 vh-100">
   <h1 class="f3 lh-copy pt3 mv0">Find the Best Quality<br>Clinical Evidence.</h1>
   <%= link "Log in", to: session_path(@conn, :new), class: "pointer db pa2 b br2 mv4 bg-white bep-blue w4 center link" %>
+  or
+  <%= link "Create a BestEvidence Account", to: consent_path(@conn, :index), class: "pointer db pa2 b br2 mv4 bg-white bep-blue w5 center link" %>
   <a href="/about" class="white underline">About Best Evidence</a>
-</div>
-<div class="bep-bg-blue white pa4">
-  <div class="center tc-ns">
-    <img src="images/white-info.svg" alt="info" class="v-mid pl3-ns">
-    <p class="b w-50-ns dib tl">Getting Started</p>
-  </div>
-  <p class="w-50-ns center">Best Evidence is only available to those willing to share their searches
-  and notes.</p>
-  <p class="w-50-ns center">To create a profile please agree to share the content of your searches and
-  notes.</p>
 </div>

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -13,18 +13,3 @@
   <p class="w-50-ns center">To create a profile please agree to share the content of your searches and
   notes.</p>
 </div>
-<div class="pa3 w-50-ns center">
-  <p class="ph3">Granting us access to your data will help us to improve:</p>
-  <ul class="b">
-    <li>Accuracy of search results</li>
-    <li>Quality of answers</li>
-    <li>Most useful features to include</li>
-  </ul>
-  <img src="images/blue-info.svg" alt="info" class="v-mid pl2 pl3-ns pr1">
-  <p class="dib bep-blue">
-    All of your data will be anonymised
-  </p>
-  <div class="tc mv5">
-    <%= link "I Agree", to: user_path(@conn, :new), class: "pointer bep-bg-green white ph4 pv3 br2 link" %>
-  </div>
-</div>

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -2,6 +2,6 @@
   <h1 class="f3 lh-copy pt3 mv0">Find the Best Quality<br>Clinical Evidence.</h1>
   <%= link "Log in", to: session_path(@conn, :new), class: "pointer db pa2 b br2 mv4 bg-white bep-blue w4 center link" %>
   or
-  <%= link "Create a BestEvidence Account", to: consent_path(@conn, :index), class: "pointer db pa2 b br2 mv4 bg-white bep-blue w5 center link" %>
+  <%= link "Create an Account", to: consent_path(@conn, :index), class: "pointer db pa2 b br2 mv4 bg-white bep-blue w5 center link" %>
   <a href="/about" class="white underline">About Best Evidence</a>
 </div>

--- a/web/templates/session/new.html.eex
+++ b/web/templates/session/new.html.eex
@@ -1,4 +1,4 @@
-<section class="bep-bg-green tc white pb3">
+<section class="bep-bg-green tc white pv5">
   <h1 class="f3 fw1 lh-copy pt3 mv0">Welcome Back.</h1>
 </section>
 <section class="pa3 w-80 w-30-ns center">
@@ -13,7 +13,7 @@
     <p class="pl1 gray dib">Min 6 characters</p>
     <div class="tc pt3">
       <%= submit "Start Searching", class: "bep-bg-green white ph4 pv3 ba br2 link db mb4 center pointer" %>
-      <%= link "Register a New Account", to: user_path(@conn, :new), class: "gray"%>
+      <%= link "Register a New Account", to: consent_path(@conn, :index), class: "gray"%>
     </div>
   <% end %>
 </section>

--- a/web/templates/user/new.html.eex
+++ b/web/templates/user/new.html.eex
@@ -1,4 +1,4 @@
-<section class="bep-bg-green tc white pb3">
+<section class="bep-bg-green tc white pv5">
   <h1 class="f3 fw1 lh-copy mv0 pt3">Great. Let's get started.</h1>
 </section>
 <section class="pa3 w-80 w-30-ns center tc">
@@ -21,7 +21,7 @@
       <p class="pl1 gray dib">Min 6 characters</p>
     </div>
     <div class="tc pt4">
-      <%= submit "Start Searching", class: "pointer bep-bg-green white ph4 pv2 ba br2 link" %>
+      <%= submit "Start Searching", class: "bep-bg-green white ph4 pv3 ba br2 link db mb4 center pointer" %>
     </div>
   <% end %>
 </section>

--- a/web/views/consent_view.ex
+++ b/web/views/consent_view.ex
@@ -1,0 +1,3 @@
+defmodule Bep.ConsentView do
+  use Bep.Web, :view
+end


### PR DESCRIPTION
ref: #69 

- display "login" and "create account" links on home page
- create consent page
- if consent agree, the user access the create account page
- the "create account" on the login page redirect now to the consent page