### PR TITLE
display type evidence

### DIFF
--- a/web/static/assets/images/pyramid-grade1.svg
+++ b/web/static/assets/images/pyramid-grade1.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="250px" height="250px" viewBox="0 0 250 250" enable-background="new 0 0 250 250" xml:space="preserve">
+<polygon fill="#63C608" points="124.928,34.246 100.11,77.246 149.785,77.246 "/>
+<polygon fill="#E6E6E6" points="75.292,120.246 174.643,120.246 149.785,77.246 100.11,77.246 "/>
+<polygon fill="#E6E6E6" points="50.474,163.246 199.498,163.246 174.643,120.246 75.292,120.246 "/>
+<polygon fill="#E6E6E6" points="25.655,206.246 224.354,206.246 199.498,163.246 50.474,163.246 "/>
+<polygon fill="#E6E6E6" points="224.354,206.246 25.655,206.246 4.354,243.152 4.354,249.246 249.211,249.246 "/>
+</svg>

--- a/web/static/assets/images/pyramid-grade2.svg
+++ b/web/static/assets/images/pyramid-grade2.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="250px" height="250px" viewBox="0 0 250 250" enable-background="new 0 0 250 250" xml:space="preserve">
+<polygon fill="#E6E6E6" points="124.928,34.246 100.11,77.246 149.785,77.246 "/>
+<polygon fill="#1D71B8" points="75.292,120.246 174.643,120.246 149.785,77.246 100.11,77.246 "/>
+<polygon fill="#E6E6E6" points="50.474,163.246 199.498,163.246 174.643,120.246 75.292,120.246 "/>
+<polygon fill="#E6E6E6" points="25.655,206.246 224.354,206.246 199.498,163.246 50.474,163.246 "/>
+<polygon fill="#E6E6E6" points="224.354,206.246 25.655,206.246 4.354,243.152 4.354,249.246 249.211,249.246 "/>
+</svg>

--- a/web/static/assets/images/pyramid-grade3.svg
+++ b/web/static/assets/images/pyramid-grade3.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="250px" height="250px" viewBox="0 0 250 250" enable-background="new 0 0 250 250" xml:space="preserve">
+<polygon fill="#E6E6E6" points="124.928,34.246 100.11,77.246 149.785,77.246 "/>
+<polygon fill="#E6E6E6" points="75.292,120.246 174.642,120.246 149.785,77.246 100.11,77.246 "/>
+<polygon fill="#00A89D" points="50.474,163.246 199.498,163.246 174.642,120.246 75.292,120.246 "/>
+<polygon fill="#E6E6E6" points="25.655,206.246 224.354,206.246 199.498,163.246 50.474,163.246 "/>
+<polygon fill="#E6E6E6" points="224.354,206.246 25.655,206.246 4.354,243.153 4.354,249.246 249.211,249.246 "/>
+</svg>

--- a/web/static/assets/images/pyramid-grade4.svg
+++ b/web/static/assets/images/pyramid-grade4.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="250px" height="250px" viewBox="0 0 250 250" enable-background="new 0 0 250 250" xml:space="preserve">
+<polygon fill="#E6E6E6" points="124.928,34.246 100.11,77.246 149.785,77.246 "/>
+<polygon fill="#E6E6E6" points="75.292,120.246 174.642,120.246 149.785,77.246 100.11,77.246 "/>
+<polygon fill="#E6E6E6" points="50.474,163.246 199.498,163.246 174.642,120.246 75.292,120.246 "/>
+<polygon fill="#BA390D" points="25.655,206.246 224.354,206.246 199.498,163.246 50.474,163.246 "/>
+<polygon fill="#E6E6E6" points="224.354,206.246 25.655,206.246 4.354,243.153 4.354,249.246 249.211,249.246 "/>
+</svg>

--- a/web/static/assets/images/pyramid-grade5.svg
+++ b/web/static/assets/images/pyramid-grade5.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="250px" height="250px" viewBox="0 0 250 250" enable-background="new 0 0 250 250" xml:space="preserve">
+<polygon fill="#E6E6E6" points="124.928,34.246 100.11,77.246 149.785,77.246 "/>
+<polygon fill="#E6E6E6" points="75.292,120.246 174.642,120.246 149.785,77.246 100.11,77.246 "/>
+<polygon fill="#E6E6E6" points="50.474,163.246 199.498,163.246 174.642,120.246 75.292,120.246 "/>
+<polygon fill="#E6E6E6" points="25.655,206.246 224.354,206.246 199.498,163.246 50.474,163.246 "/>
+<polygon fill="#E6C82F" points="224.354,206.246 25.655,206.246 4.354,243.153 4.354,249.246 249.211,249.246 "/>
+</svg>

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -63,3 +63,24 @@ body {
 .bep-white-ph:-ms-input-placeholder {
   color:#fff;
 }
+
+/*based evidence pyramid colours*/
+.b--evidence-1 {
+  border-color: #87cf44
+}
+
+.b--evidence-2 {
+  border-color: #518ec8
+}
+
+.b--evidence-3 {
+  border-color: #30b5ae
+}
+
+.b--evidence-4 {
+  border-color: #c86547
+}
+
+.b--evidence-5 {
+  border-color: #e9d161
+}

--- a/web/templates/search/results.html.eex
+++ b/web/templates/search/results.html.eex
@@ -8,10 +8,10 @@
 <section class="ph2 w-50-ns center">
   <h2 class="f6 pb2 bw1 bb bep-b--blue"> <%= @data["total"] %> Results</h2>
   <ul class="ph1 list">
-    <%= for {evidence, i} <- Enum.with_index(@data["documents"]) do %>
+    <%= for {evidence, i} <- Enum.with_index(@data["documents"], 1) do %>
       <div class="dt link bl bw2 pl2 mv3 w-100 <%=colour_evidence(evidence["categoryid"])%>">
         <div class="dtc fw9 w-75">
-          <%= i + 1 %>. <%= link evidence["title"], to: evidence["link"], class: "link bep-blue publication", target: "_blank", "data-search-id": @id %>
+          <%= i %>. <%= link evidence["title"], to: evidence["link"], class: "link bep-blue publication", target: "_blank", "data-search-id": @id %>
         </div>
 
         <div class="dtc w-25 v-mid tr">

--- a/web/templates/search/results.html.eex
+++ b/web/templates/search/results.html.eex
@@ -9,7 +9,15 @@
   <h2 class="f6 pb2 bw1 bb bep-b--blue"> <%= @data["total"] %> Results</h2>
   <ul class="ph1 list">
     <%= for {evidence, i} <- Enum.with_index(@data["documents"]) do %>
-      <li class="bl bw2 mv3 pl2 fw9 pr4"><%= i + 1 %>. <%= link evidence["title"], to: evidence["link"], class: "link bep-blue publication", target: "_blank", "data-search-id": @id %> </li>
+      <div class="dt link bl bw2 pl2 mv3 w-100 <%=colour_evidence(evidence["categoryid"])%>">
+        <div class="dtc fw9 w-75">
+          <%= i + 1 %>. <%= link evidence["title"], to: evidence["link"], class: "link bep-blue publication", target: "_blank", "data-search-id": @id %>
+        </div>
+
+        <div class="dtc w-25 v-mid tr">
+          <img src="/images/<%= pyramid_logo(evidence["categoryid"])%>" alt="pyramid grade" width="25" height="25">
+        </div>
+      </div>
     <% end %>
   </ul>
 </section>

--- a/web/views/search_view.ex
+++ b/web/views/search_view.ex
@@ -1,3 +1,24 @@
 defmodule Bep.SearchView do
   use Bep.Web, :view
+  def colour_evidence(type) do
+    cond do
+      Enum.member?([1, 4, 9, 10, 11, 16, 18, 34], type) -> "b--evidence-1"
+      type == 13 -> "b--evidence-2"
+      type == 2 -> "b--evidence-3"
+      Enum.member?([27, 14], type) -> "b--evidence-4"
+      Enum.member?([5, 8, 22, 29, 30, 35], type) -> "b--evidence-5"
+      true -> "b--white"
+    end
+  end
+
+  def pyramid_logo(type) do
+    cond do
+      Enum.member?([1, 4, 9, 10, 11, 16, 18, 34], type) -> "pyramid-grade1.svg"
+      type == 13 -> "pyramid-grade2.svg"
+      type == 2 -> "pyramid-grade3.svg"
+      Enum.member?([27, 14], type) -> "pyramid-grade4.svg"
+      Enum.member?([5, 8, 22, 29, 30, 35], type) -> "pyramid-grade5.svg"
+      true -> ""
+    end
+  end
 end

--- a/web/views/search_view.ex
+++ b/web/views/search_view.ex
@@ -1,24 +1,22 @@
 defmodule Bep.SearchView do
   use Bep.Web, :view
-  def colour_evidence(type) do
+  defp format_class(type, format_string) do
     cond do
-      Enum.member?([1, 4, 9, 10, 11, 16, 18, 34], type) -> "b--evidence-1"
-      type == 13 -> "b--evidence-2"
-      type == 2 -> "b--evidence-3"
-      Enum.member?([27, 14], type) -> "b--evidence-4"
-      Enum.member?([5, 8, 22, 29, 30, 35], type) -> "b--evidence-5"
-      true -> "b--white"
+      type in [1, 4, 9, 10, 11, 16, 18, 34] -> format_string.(1)
+      type == 13 -> format_string.(2)
+      type == 2 -> format_string.(3)
+      type in [27, 14] -> format_string.(4)
+      type in [5, 8, 22, 29, 30, 35] -> format_string.(5)
+      true -> format_string.(0)
     end
   end
 
-  def pyramid_logo(type) do
-    cond do
-      Enum.member?([1, 4, 9, 10, 11, 16, 18, 34], type) -> "pyramid-grade1.svg"
-      type == 13 -> "pyramid-grade2.svg"
-      type == 2 -> "pyramid-grade3.svg"
-      Enum.member?([27, 14], type) -> "pyramid-grade4.svg"
-      Enum.member?([5, 8, 22, 29, 30, 35], type) -> "pyramid-grade5.svg"
-      true -> ""
-    end
-  end
+  defp colour_evidence_format(int) when int == 0, do: "b--white"
+  defp colour_evidence_format(int), do: "b--evidence-#{int}"
+
+  defp pyramid_logo_format(int) when int == 0, do: ""
+  defp pyramid_logo_format(int), do: "pyramid-grade#{int}.svg"
+
+  def colour_evidence(type), do: format_class(type, &colour_evidence_format/1)
+  def pyramid_logo(type), do: format_class(type, &pyramid_logo_format/1)
 end


### PR DESCRIPTION
ref: #75
Display the right colours and the correct pyramid logo depending on the type of evidence:
![image](https://user-images.githubusercontent.com/6057298/28617678-380709b8-71f9-11e7-9921-009686dcccd0.png)
