### PR TITLE
Redirect login

### DIFF
--- a/test/controllers/session_controller_test.exs
+++ b/test/controllers/session_controller_test.exs
@@ -1,0 +1,14 @@
+defmodule Bep.SessionControllerTest do
+  use Bep.ConnCase
+
+  test "GET /users/new", %{conn: conn} do
+    conn = get conn, user_path(conn, :new)
+    assert html_response(conn, 200) =~ "Great. Let's get started."
+  end
+
+  test "POST /users/create redirect to /login when email already linked to an account", %{conn: conn} do
+    insert_user()
+    conn = post conn, user_path(conn, :create, %{"user" => %{"email": "email@example.com", "password": "supersecret"}})
+    assert html_response(conn, 302)
+  end
+end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -16,7 +16,12 @@ defmodule Bep.UserController do
         |> put_flash(:info, "Welcome to BestEvidence!")
         |> redirect(to: page_path(conn, :index))
       {:error, changeset} ->
-        render(conn, "new.html", changeset: changeset)
+        if elem(changeset.errors[:email], 0) == "has already been taken" do
+          conn
+          |> redirect(to: session_path(conn, :new))
+        else
+          render(conn, "new.html", changeset: changeset)
+        end
     end
   end
 


### PR DESCRIPTION
ref: #77 
Redirect the user to the login page when she attempts to create a new user with an email already linked to an account