### PR TITLE
remove duplicate code in history controller

### DIFF
--- a/web/controllers/history_contorller.ex
+++ b/web/controllers/history_contorller.ex
@@ -5,7 +5,6 @@ defmodule Bep.HistoryController do
   defp get_history(u) do
     User
     |> Repo.get!(u.id)
-    |> Repo.preload(:searches)
     |> Repo.preload(
       searches: from(s in Search, order_by: [desc: s.inserted_at])
     )
@@ -30,7 +29,6 @@ defmodule Bep.HistoryController do
     |> Enum.group_by(
       fn(s) -> Date.to_string(s.inserted_at)
     end)
-    |> Enum.map(fn {key, value} -> {key, value} end)
     |> Enum.sort(fn({k1, _}, {k2, _}) -> k1 >= k2 end)
   end
 end


### PR DESCRIPTION
ref #115

This PR clean the ecto query which get the history searches by deleting unnecessary code