### PR TITLE
allow user to create empty note

### DIFF
--- a/test/controllers/note_publication_controller_test.exs
+++ b/test/controllers/note_publication_controller_test.exs
@@ -49,22 +49,6 @@ defmodule Bep.NotePublicationControllerTest do
   end
 
   @tag login_as: %{email: "email@example.com"}
-  test "POST /note/publication create empty note", %{conn: conn, user: user} do
-    search = insert_search(user)
-    publication = insert_publication(search)
-    conn = post conn, note_publication_path(
-      conn,
-      :create,
-      %{"note_publication" => %{
-        "note" => "",
-        "user_id" => user.id,
-        "publication_id" => publication.id}
-       }
-    )
-    assert html_response(conn, 200)
-  end
-
-  @tag login_as: %{email: "email@example.com"}
   test "GET /note/search edit", %{conn: conn, user: user} do
     search = insert_search(user)
     publication = insert_publication(search)
@@ -96,26 +80,6 @@ defmodule Bep.NotePublicationControllerTest do
         }
       )
     assert html_response(conn, 302)
-  end
-
-  @tag login_as: %{email: "email@example.com"}
-  test "PUT /note/publication update note empty", %{conn: conn, user: user} do
-    search = insert_search(user)
-    publication = insert_publication(search)
-    note = insert_note_publication(publication, user)
-    conn = put conn, note_publication_path(
-      conn,
-      :update,
-      note,
-      %{
-        "id" => note.id,
-        "note_publication" => %{
-          "note" => "",
-          "user_id" => user.id,
-          "publication_id" => publication.id}
-        }
-      )
-    assert html_response(conn, 200)
   end
 
 end

--- a/test/controllers/note_search_controller_test.exs
+++ b/test/controllers/note_search_controller_test.exs
@@ -40,17 +40,6 @@ defmodule Bep.NoteSearchControllerTest do
   end
 
   @tag login_as: %{email: "email@example.com"}
-  test "POST /note/search create - empty note", %{conn: conn, user: user} do
-    search = insert_search(user)
-    conn = post conn, note_search_path(
-      conn,
-      :create,
-      %{"note_search" => %{"note" => "", "search_id" => search.id}}
-    )
-    assert html_response(conn, 200)
-  end
-
-  @tag login_as: %{email: "email@example.com"}
   test "GET /note/search edit", %{conn: conn, user: user} do
     search = insert_search(user)
     note = insert_note(search)
@@ -72,22 +61,6 @@ defmodule Bep.NoteSearchControllerTest do
       }
       )
     assert html_response(conn, 302)
-  end
-
-  @tag login_as: %{email: "email@example.com"}
-  test "PUT /note/search update note empty", %{conn: conn, user: user} do
-    search = insert_search(user)
-    note = insert_note(search)
-    conn = put conn, note_search_path(
-      conn,
-      :update,
-      note,
-      %{
-        "id" => note.id,
-        "note_search" => %{"note" => "", "search_id" => search.id}
-      }
-      )
-    assert html_response(conn, 200)
   end
 
 end

--- a/web/controllers/note_publication_controller.ex
+++ b/web/controllers/note_publication_controller.ex
@@ -10,14 +10,9 @@ defmodule Bep.NotePublicationController do
 
   def create(conn, %{"note_publication" => note_params}) do
     changeset = NotePublication.changeset(%NotePublication{}, note_params)
-    case Repo.insert(changeset) do
-      {:ok, _note} ->
-        conn
-        |> redirect(to: history_path(conn, :index))
-      {:error, changeset} ->
-        publication = Repo.get!(Publication, note_params["publication_id"])
-        render conn, "new.html", changeset: changeset, publication: publication
-    end
+    Repo.insert!(changeset)
+    conn
+    |> redirect(to: history_path(conn, :index))
   end
 
   def edit(conn, %{"id" => note_id, "publication_id" => publication_id}) do
@@ -30,15 +25,9 @@ defmodule Bep.NotePublicationController do
   def update(conn, %{"id" => note_id, "note_publication" => note_params}) do
     note = Repo.get!(NotePublication, note_id)
     changeset = NotePublication.changeset(note, note_params)
-
-    case Repo.update(changeset) do
-      {:ok, _note} ->
-        conn
-        |> redirect(to: history_path(conn, :index))
-      {:error, changeset} ->
-        publication = Repo.get!(Publication, note_params["publication_id"])
-        render conn, "edit.html", changeset: changeset, publication: publication
-    end
+    Repo.update!(changeset)
+    conn
+    |> redirect(to: history_path(conn, :index))
   end
 
 end

--- a/web/controllers/note_search_controller.ex
+++ b/web/controllers/note_search_controller.ex
@@ -10,14 +10,9 @@ defmodule Bep.NoteSearchController do
 
   def create(conn, %{"note_search" => note_params}) do
     changeset = NoteSearch.changeset(%NoteSearch{}, note_params)
-    case Repo.insert(changeset) do
-      {:ok, _note} ->
-        conn
-        |> redirect(to: history_path(conn, :index))
-      {:error, changeset} ->
-        search = Repo.get!(Search, note_params["search_id"])
-        render conn, "new.html", changeset: changeset, search: search
-    end
+    Repo.insert!(changeset)
+    conn
+    |> redirect(to: history_path(conn, :index))
   end
 
   def edit(conn, %{"id" => note_id, "search_id" => search_id}) do
@@ -30,14 +25,8 @@ defmodule Bep.NoteSearchController do
   def update(conn, %{"id" => note_id, "note_search" => note_params}) do
     note = Repo.get!(NoteSearch, note_id)
     changeset = NoteSearch.changeset(note, note_params)
-
-    case Repo.update(changeset) do
-      {:ok, _note} ->
-        conn
-        |> redirect(to: history_path(conn, :index))
-      {:error, changeset} ->
-        search = Repo.get!(Search, note_params["search_id"])
-        render conn, "edit.html", changeset: changeset, search: search
-    end
+    Repo.update!(changeset)
+    conn
+    |> redirect(to: history_path(conn, :index))
   end
 end

--- a/web/models/note_publication.ex
+++ b/web/models/note_publication.ex
@@ -15,6 +15,6 @@ defmodule Bep.NotePublication do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:note, :publication_id, :user_id])
-    |> validate_required([:note, :publication_id, :user_id])
+    |> validate_required([:publication_id, :user_id])
   end
 end

--- a/web/models/note_search.ex
+++ b/web/models/note_search.ex
@@ -15,6 +15,6 @@ defmodule Bep.NoteSearch do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:note, :search_id])
-    |> validate_required([:note, :search_id])
+    |> validate_required([:search_id])
   end
 end


### PR DESCRIPTION
ref #145
Users are now allow to crate empty notes
Remove the validation requirement on the changeset for search_note and publication_note.