### PR TITLE
change color of visited links (lighter blue)

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -111,3 +111,7 @@ body {
 .mt3-plus {
   margin-top: 0.2rem;
 }
+
+.link:visited {
+  color: #7ea8ca;
+}


### PR DESCRIPTION
ref: #163
Allow user to distinguish between already clicked links and non clicked links by defining a different colour for visited links:
![image](https://user-images.githubusercontent.com/6057298/29584865-02e0f520-877d-11e7-8fc3-cc8c7cc1d506.png)
