### PR TITLE
laod dynamically js for filte button on search page

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -15,17 +15,6 @@ import "phoenix_html"
 import "./publication"
 import "./load_search"
 
-function filterEvidence () {
-  var evidenceType = document.getElementById('evidence-type');
-  if (evidenceType.style.display == 'none' || evidenceType.style.display == '') {
-    evidenceType.style.display = 'block';
-  } else {
-    evidenceType.style.display = 'none';
-  }
-}
-
-document.getElementById('filter-evidence').addEventListener('click', filterEvidence);
-
 // Import local files
 //
 // Local files can be imported directly using relative

--- a/web/static/js/results_filter.js
+++ b/web/static/js/results_filter.js
@@ -1,0 +1,15 @@
+/*
+* Toggle for evidence type filter menu
+*/
+module.exports = (function() {
+  document.getElementById('filter-evidence').addEventListener('click', filterEvidence);
+
+  function filterEvidence () {
+    var evidenceType = document.getElementById('evidence-type');
+    if (evidenceType.style.display == 'none' || evidenceType.style.display == '') {
+      evidenceType.style.display = 'block';
+    } else {
+      evidenceType.style.display = 'none';
+    }
+  }
+})()

--- a/web/views/search_view.ex
+++ b/web/views/search_view.ex
@@ -18,6 +18,7 @@ defmodule Bep.SearchView do
 
   def render("scripts.results.html", _assigns) do
     ~s{<script>require("web/static/js/results_lazy_loading")</script>}
+    <> ~s{<script>require("web/static/js/results_filter")</script>}
     |> raw
   end
 


### PR DESCRIPTION
ref: #167

The javascript for the filter (toggle button) was loaded on all the pages which was producing an error when the filter dom element wasn't present on the page. We are now loading the js only on the result page.