### PR TITLE
add simple regex validation on email for user changeset

### DIFF
--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -3,7 +3,7 @@ defmodule Bep.UserTest do
   alias Bep.User
 
   @valid_attrs %{email: "email@example.com", password: "supersecret"}
-  @invalid_attrs_email %{email: "email@example.com    ", password: "supersecret"}
+  @invalid_attrs_email %{email: "email-example.com    ", password: "supersecret"}
 
   test "user changeset with valid attributes" do
     changeset = User.changeset(%User{}, @valid_attrs)

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -1,0 +1,17 @@
+defmodule Bep.UserTest do
+  use Bep.ModelCase
+  alias Bep.User
+
+  @valid_attrs %{email: "email@example.com", password: "supersecret"}
+  @invalid_attrs_email %{email: "email@example.com    ", password: "supersecret"}
+
+  test "user changeset with valid attributes" do
+    changeset = User.changeset(%User{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "user changeset invalid email" do
+    changeset = User.changeset(%User{}, @invalid_attrs_email)
+    refute changeset.valid?
+  end
+end

--- a/web/controllers/search_controller.ex
+++ b/web/controllers/search_controller.ex
@@ -42,7 +42,13 @@ defmodule Bep.SearchController do
         case Repo.insert(changeset) do
           {:ok, search} ->
             conn
-            |> render("results.html", search: term, data: data, id: search.id)
+            |> render(
+              "results.html",
+              search: changeset.changes.term,
+              data: data,
+              id: search.id,
+              search_changeset: changeset
+            )
           {:error, _changeset} ->
             conn
             |> put_flash(:error, "Oops, something wrong happen, please try again.")

--- a/web/models/search.ex
+++ b/web/models/search.ex
@@ -18,12 +18,22 @@ defmodule Bep.Search do
     struct
     |> cast(params, [:term])
     |> validate_required([:term])
+    |> trim_term()
   end
 
   def create_changeset(model, params, number_results) do
     model
     |> changeset(params)
     |> put_change(:number_results, number_results)
+  end
+
+  defp trim_term(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{term: term}} ->
+        put_change(changeset, :term, String.trim(term))
+      _ ->
+        changeset
+    end
   end
 
   def group_searches_by_day(searches) do

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -20,7 +20,7 @@ defmodule Bep.User do
     |> cast(params, [:email])
     |> validate_required([:email])
     |> email_lowercase()
-    |> validate_format(:email, ~r/.+\@.+\.\S+$/)
+    |> validate_format(:email, ~r/@/)
     |> unique_constraint(:email)
   end
 
@@ -45,7 +45,13 @@ defmodule Bep.User do
   defp email_lowercase(changeset) do
     case changeset do
       %Ecto.Changeset{valid?: true, changes: %{email: email}} ->
-        put_change(changeset, :email, String.downcase(email))
+        put_change(
+          changeset,
+          :email,
+          email
+          |> String.downcase()
+          |> String.trim()
+        )
       _ ->
         changeset
     end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -20,6 +20,7 @@ defmodule Bep.User do
     |> cast(params, [:email])
     |> validate_required([:email])
     |> email_lowercase()
+    |> validate_format(:email, ~r/.+\@.+\.\S+$/)
     |> unique_constraint(:email)
   end
 

--- a/web/templates/search/results.html.eex
+++ b/web/templates/search/results.html.eex
@@ -1,7 +1,7 @@
 <section class="bep-bg-maroon pv3 mt3 tc bb bep-b--maroon bw1 fixed w-100">
   <span class="dn-ns"><i class="fa fa-search white pr1-ns dn" aria-hidden="true"></i></span>
   <span class="white dn dib-ns">Search terms:</span>
-  <%= form_for @conn, search_path(@conn, :create), [as: :search, class: "dib"], fn f -> %>
+  <%= form_for @search_changeset, search_path(@conn, :create), [as: :search, class: "dib"], fn f -> %>
     <%= text_input f, :term, placeholder: "Enter search here", class: "bep-white-ph bep-bg-light-maroon white pa2 w-90 w5-ns ba br2 b--black-20 dib" %>
     <%= hidden_input f, :search_id, value: @id, id: "search-id" %>
   <% end %>


### PR DESCRIPTION
ref: #170
https://github.com/dwyl/best-evidence/blob/validate-email-format/web/models/user.ex#L23
~r/.+\@.+\.\S+$/:
- .+ - any characters
- \@ - follow by @
- .+ - follow by any characters
- \. - follow by a dot
- \S+ - follow by any characters which are not spaces
- $ - end of the term

The most important part for me is \S+$ as it tell the user if some trailing spaces have been added by mistake. This error already occurs in our staging database that's why I focus on this.