### PR TITLE
display publication on note page

### DIFF
--- a/test/views/note_view_test.exs
+++ b/test/views/note_view_test.exs
@@ -1,0 +1,4 @@
+defmodule Bep.NoteViewTest do
+  use Bep.ConnCase, async: true
+  doctest Bep.NoteView, import: true
+end

--- a/web/templates/note/index.html.eex
+++ b/web/templates/note/index.html.eex
@@ -1,33 +1,31 @@
 <section class="pt2 pt5-l pb4 mt4 w-80 w-50-ns center">
   <h4 class="f5 dib w-60">Notes</h4>
   <article class="f6 pb4">
-    <%= for {date, searches} <- @searches do %>
-      <%= for search <- searches do %>
-        <%= if !search.note_searches do %>
-          <%= if has_note_publications?(search) do %>
-            <div class="db pb3 tl">
-              <p class="mt0 mb1 dib pr3 b"><%= format_date(date) %></p>
-              <span> <%= search.term %> </span>
-              <%= for publication <- search.publications do %>
-                <%= if List.first(publication.note_publications) do %>
-                  <p class="pl3 db"> <%= publication.value %>
+    <%= for {date, searches} <- @searches, search <- searches do %>
+      <%= if !search.note_searches do %>
+        <%= if has_note_publications?(search) do %>
+          <div class="db pb3 tl">
+            <p class="mt0 mb1 dib pr3 b"><%= format_date(date) %></p>
+            <span> <%= search.term %> </span>
+            <%= for publication <- search.publications do %>
+              <%= if List.first(publication.note_publications) do %>
+                <p class="pl3 db"> <%= publication.value %>
                   <%= link to: note_publication_path(@conn, :edit, List.first(publication.note_publications), publication_id: publication.id), class: "black link" do %>
                     <i class="fa fa-pencil pl2" aria-hidden="true"></i>
                   <%end %>
                 </p>
-                <% end %>
               <% end %>
-            </div>
-          <% end %>
-        <% else %>
-          <div class="db pb3 tl">
-            <p class="mt0 mb1 dib pr3 b"><%= format_date(date) %></p>
-            <span class="pr2"> <%= search.term %> </span>
-            <%= link to: note_search_path(@conn, :edit, search.note_searches, search_id: search.id), class: "black link" do %>
-              <i class="fa fa-pencil" aria-hidden="true"></i>
-            <%end %>
+            <% end %>
           </div>
         <% end %>
+      <% else %>
+        <div class="db pb3 tl">
+          <p class="mt0 mb1 dib pr3 b"><%= format_date(date) %></p>
+          <span class="pr2"> <%= search.term %> </span>
+          <%= link to: note_search_path(@conn, :edit, search.note_searches, search_id: search.id), class: "black link" do %>
+            <i class="fa fa-pencil" aria-hidden="true"></i>
+          <%end %>
+        </div>
       <% end %>
     <% end %>
   </article>

--- a/web/templates/note/index.html.eex
+++ b/web/templates/note/index.html.eex
@@ -3,11 +3,30 @@
   <article class="f6 pb4">
     <%= for {date, searches} <- @searches do %>
       <%= for search <- searches do %>
-        <%= if search.note_searches do %>
-        <div class="db pb3 tl">
-          <p class="mt0 mb1 dib pr3 b"><%= format_date(date) %></p>
-          <%= link search.term, to: note_search_path(@conn, :edit, search.note_searches, search_id: search.id), class: "black link"%>
-        </div>
+        <%= if !search.note_searches do %>
+          <%= if has_note_publications?(search) do %>
+            <div class="db pb3 tl">
+              <p class="mt0 mb1 dib pr3 b"><%= format_date(date) %></p>
+              <span> <%= search.term %> </span>
+              <%= for publication <- search.publications do %>
+                <%= if List.first(publication.note_publications) do %>
+                  <p class="pl3 db"> <%= publication.value %>
+                  <%= link to: note_publication_path(@conn, :edit, List.first(publication.note_publications), publication_id: publication.id), class: "black link" do %>
+                    <i class="fa fa-pencil pl2" aria-hidden="true"></i>
+                  <%end %>
+                </p>
+                <% end %>
+              <% end %>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="db pb3 tl">
+            <p class="mt0 mb1 dib pr3 b"><%= format_date(date) %></p>
+            <span class="pr2"> <%= search.term %> </span>
+            <%= link to: note_search_path(@conn, :edit, search.note_searches, search_id: search.id), class: "black link" do %>
+              <i class="fa fa-pencil" aria-hidden="true"></i>
+            <%end %>
+          </div>
         <% end %>
       <% end %>
     <% end %>

--- a/web/views/note_view.ex
+++ b/web/views/note_view.ex
@@ -2,4 +2,14 @@ defmodule Bep.NoteView do
   use Bep.Web, :view
 
   defdelegate format_date(date), to: Bep.HistoryView, as: :format_date
+
+  def has_note_publications?(search) do
+    if Enum.empty?(search.publications) do
+      false
+    else
+      Enum.reduce(search.publications, false, fn(p, acc) ->
+        acc || !Enum.empty?(p.note_publications)
+      end)
+    end
+  end
 end

--- a/web/views/note_view.ex
+++ b/web/views/note_view.ex
@@ -3,6 +3,14 @@ defmodule Bep.NoteView do
 
   defdelegate format_date(date), to: Bep.HistoryView, as: :format_date
 
+  @doc"""
+    iex> s = %{publications: []}
+    iex>has_note_publications?(s)
+    false
+    iex> s = %{publications: [%{note_publications: [%{note: "note"}]}]}
+    iex>has_note_publications?(s)
+    true
+  """
   def has_note_publications?(search) do
     if Enum.empty?(search.publications) do
       false

--- a/web/views/note_view.ex
+++ b/web/views/note_view.ex
@@ -11,13 +11,7 @@ defmodule Bep.NoteView do
     iex>has_note_publications?(s)
     true
   """
-  def has_note_publications?(search) do
-    if Enum.empty?(search.publications) do
-      false
-    else
-      Enum.reduce(search.publications, false, fn(p, acc) ->
-        acc || !Enum.empty?(p.note_publications)
-      end)
-    end
-  end
+  def has_note_publications?(%{publications: []}), do: false
+  def has_note_publications?(%{publications: publications}),
+    do: Enum.any? publications, &(&1.note_publications != [])
 end


### PR DESCRIPTION
ref: #22
The note page show the search terms and the publications containing notes:
![image](https://user-images.githubusercontent.com/6057298/29993951-9a83d3d8-8fbc-11e7-9066-44b46d0baa9f.png)

When a publication has a note but not the search term linked to the publication, the edit icon is not show on the search