### PR TITLE
force trigger click event on ios

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -141,3 +141,7 @@ body {
 .w1-plus {
   width: 1.9rem;
 }
+
+.add-note {
+  cursor: pointer;
+}

--- a/web/templates/search/evidences.html.eex
+++ b/web/templates/search/evidences.html.eex
@@ -27,7 +27,9 @@
             <% end %>
           </a>
         <% else %>
-          <i class="fa fa-plus pointer add-note" aria-hidden="true" data-evidence-id="<%= evidence["id"] %>"></i>
+          <div class="add-note" data-evidence-id="<%= evidence["id"] %>">
+            <i class="fa fa-plus pointer" aria-hidden="true" data-evidence-id="<%= evidence["id"] %>"></i>
+          </div>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
ref: https://github.com/dwyl/best-evidence/issues/211#issuecomment-331164663

The click events are not triggered by default on ios (it's replaced by touch event). So to force the click event a solution is to define the curson as a pointer in css:
https://stackoverflow.com/questions/3705937/document-click-not-working-correctly-on-iphone-jquery